### PR TITLE
Fixed problem with refs ending in '#'

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -82,5 +82,5 @@ exports.getRefPathValue = function (schema, refPath) {
   if(rpath) {
     return mpath.get(rpath, schema);
   }
-  else return;
+  else return schema;
 };

--- a/test/index.js
+++ b/test/index.js
@@ -108,6 +108,17 @@ describe('json-schema-deref', function () {
       });
     });
 
+    it('should work with simple web refs ended with #', function (done) {
+      var input = require('./schemas/webrefswithhash');
+      var expected = require('./schemas/localrefs.expected.json'); // same expected output
+
+      deref(input, function (err, schema) {
+        expect(err).to.not.be.ok;
+        expect(schema).to.deep.equal(expected);
+        done();
+      });
+    });
+
     it('should work with web and local mixed refs', function (done) {
       var input = require('./schemas/webwithlocal');
       var expected = require('./schemas/webwithlocal.expected.json');

--- a/test/schemas/webrefswithhash.json
+++ b/test/schemas/webrefswithhash.json
@@ -1,0 +1,27 @@
+{
+  "description": "Just a basic schema with refs ending in '#' (as in https://github.com/fge/sample-json-schemas/blob/master/geojson/geojson.json).",
+  "title": "Basic Object",
+  "type": "object",
+  "definitions": {
+    "id": {
+      "$ref": "https://raw.githubusercontent.com/bojand/json-schema-test-samples/master/id.json#"
+    },
+    "foo": {
+      "$ref": "https://raw.githubusercontent.com/bojand/json-schema-test-samples/master/foo.json#"
+    },
+    "bar": {
+      "$ref": "https://raw.githubusercontent.com/bojand/json-schema-test-samples/master/bar.json#"
+    }
+  },
+  "properties": {
+    "id": {
+      "$ref": "#/definitions/id"
+    },
+    "foo": {
+      "$ref": "#/definitions/foo"
+    },
+    "bar": {
+      "$ref": "#/definitions/bar"
+    }
+  }
+}

--- a/test/schemas/webrefswithhash.json
+++ b/test/schemas/webrefswithhash.json
@@ -1,5 +1,5 @@
 {
-  "description": "Just a basic schema with refs ending in '#' (as in https://github.com/fge/sample-json-schemas/blob/master/geojson/geojson.json).",
+  "description": "Just a basic schema.",
   "title": "Basic Object",
   "type": "object",
   "definitions": {


### PR DESCRIPTION
Fixes #8 

External ref ending with a single '#' character should work just as external refs without that character. This pull request fixes the problem and adds a new test case to verify it.