### PR TITLE
Remove confusing path replacement

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -62,11 +62,6 @@ function getRefSchema(refVal, refType, parent, options, state, fn) {
           dirname = '';
         }
 
-        if (dirname) {
-          oldBasePath = state.cwd;
-          var newBasePath = path.resolve(state.cwd, dirname);
-          options.baseFolder = state.cwd = newBasePath;
-        }
       }
 
       derefSchema(loaderValue, options, state, function (err, derefedValue) {


### PR DESCRIPTION
I want to use following folder structure:

config
+-- user
---- +-- shared.json
---- +-- user.json
---- +-- .....
+-- shared.json

In this structure user.json can reference user/shared.json and user/shared.json can reference config/shared.json. When the base directory changes by referencing another file it causes the behavior to be unpredictable. With a fixed base directory this problem doesn't occur for me.