### PR TITLE
Feature/repair false values

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -301,7 +301,7 @@ function derefSchema (schema, options, state, fn) {
 
       state.history.pop()
 
-      if (!err && !newValue) {
+      if (!err && _.isNil(newValue)) {
         if (state.missing.indexOf(refVal) === -1) {
           state.missing.push(refVal)
         }
@@ -320,7 +320,7 @@ function derefSchema (schema, options, state, fn) {
         obj = self.node
       }
 
-      if (obj && newValue) {
+      if (obj && !_.isNil(newValue)) {
         obj[self.key] = newValue
         if (state.missing.indexOf(refVal) !== -1) {
           state.missing.splice(state.missing.indexOf(refVal), 1)

--- a/lib/index.js
+++ b/lib/index.js
@@ -325,7 +325,7 @@ function derefSchema (schema, options, state, fn) {
         if (state.missing.indexOf(refVal) !== -1) {
           state.missing.splice(state.missing.indexOf(refVal), 1)
         }
-      } else if (self.isRoot && newValue) {
+      } else if (self.isRoot && !_.isNil(newValue)) {
         // special case of root schema being replaced
         state.history.pop()
         if (state.missing.indexOf(refVal) === -1) {


### PR DESCRIPTION
Good day,

there is a discrepancy in your library. Even though the name makes one think that it binds together schema only, you can also bind JSON together and we use that to have a nice, distributed configs.

The problem however, is that false values can not be references.
Say you have a shared.json with a timeout. When that timeout if configured to 0, it is confidered disabled. When you try to reference that value, you only get the reference string "#/shared/timeout" instead of "0".

Obviously, that is a pain and we'd like to give back to you guys.
This little snippet will repair the issue and didn't break any code.


If you desire a little sample, let me know and I'll send it to you.

Cheers,
Philipp