### PR TITLE
Switch `isNil` with `isUndefined` and allow null values

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -301,7 +301,7 @@ function derefSchema (schema, options, state, fn) {
 
       state.history.pop()
 
-      if (!err && _.isNil(newValue)) {
+      if (!err && _.isUndefined(newValue)) {
         if (state.missing.indexOf(refVal) === -1) {
           state.missing.push(refVal)
         }
@@ -320,12 +320,12 @@ function derefSchema (schema, options, state, fn) {
         obj = self.node
       }
 
-      if (obj && !_.isNil(newValue)) {
+      if (obj && !_.isUndefined(newValue)) {
         obj[self.key] = newValue
         if (state.missing.indexOf(refVal) !== -1) {
           state.missing.splice(state.missing.indexOf(refVal), 1)
         }
-      } else if (self.isRoot && !_.isNil(newValue)) {
+      } else if (self.isRoot && !_.isUndefined(newValue)) {
         // special case of root schema being replaced
         state.history.pop()
         if (state.missing.indexOf(refVal) === -1) {


### PR DESCRIPTION
Okay, here's the fix for the last PR I caused. Now we also can have null values as valid values.
Essentially: we only discourage undefined values as those are not allowed in the JSON spec.

This PR plays with #29 