### PR TITLE
Add filtering of dereferenced nodes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -251,6 +251,8 @@ function derefSchema (schema, options, state, fn) {
     return fn(check)
   }
 
+  const allowed = typeof options.filter === 'function' ? options.filter : function () { return true }
+
   if (state.circular) {
     return fn(new Error(`circular references found: ${state.circularRefs.toString()}`), null)
   } else if (state.error) {
@@ -311,6 +313,10 @@ function derefSchema (schema, options, state, fn) {
             state.error = new Error(`Missing $ref: ${refVal}`)
             return final(schema)
           }
+          return next()
+        }
+
+        if (!allowed({ newValue: newValue })) {
           return next()
         }
 


### PR DESCRIPTION
Usage:

```
    deref(schema, {
        filter: (context) => {
            return context.newValue.type === 'object'
        }
    }, (err, schemaDerefed) => {
        // 
    });
```